### PR TITLE
Only refresh mCompleteDiscoveryCallback when the device is new

### DIFF
--- a/sdk/src/main/java/com/punchthrough/bean/sdk/BeanManager.java
+++ b/sdk/src/main/java/com/punchthrough/bean/sdk/BeanManager.java
@@ -75,11 +75,13 @@ public class BeanManager {
         @Override
         public void onLeScan(BluetoothDevice device, final int rssi, byte[] scanRecord) {
             if (isBean(scanRecord)) {
-                mHandler.removeCallbacks(mCompleteDiscoveryCallback);
+                boolean oldBean = mBeans.containsKey(device.getAddress());
+                if(!oldBean)
+                    mHandler.removeCallbacks(mCompleteDiscoveryCallback);
 
                 final Bean bean;
 
-                if (mBeans.containsKey(device.getAddress())) {
+                if (oldBean) {
                     // We already know about this bean
                     bean = mBeans.get(device.getAddress());
                 } else {
@@ -99,7 +101,8 @@ public class BeanManager {
                         mListener.onBeanDiscovered(bean, rssi);
                     }
                 });
-                mHandler.postDelayed(mCompleteDiscoveryCallback, SCAN_TIMEOUT / 2);
+                if(!oldBean)
+                    mHandler.postDelayed(mCompleteDiscoveryCallback, SCAN_TIMEOUT / 2);
 
             }
         }


### PR DESCRIPTION
This fixes issue #28  where the onDiscoveryComplete() callback would never fire
if the same bean gets found over and over (which occurred while testing
with a Galaxy S5 running Android 6.0.1).