### PR TITLE
Fixed issue of writing 13 bytes sendSerialMessage with causes error Received message of unknown type 0x0001

### DIFF
--- a/sdk/src/androidTest/java/com/punchthrough/bean/sdk/TestBeanAdvanced.java
+++ b/sdk/src/androidTest/java/com/punchthrough/bean/sdk/TestBeanAdvanced.java
@@ -262,6 +262,23 @@ public class TestBeanAdvanced extends BeanTestCase {
     }
 
     @Suppress
+    public void testSerialMessages13Bytes() throws Exception {
+        final CountDownLatch testCompletionLatch = new CountDownLatch(1);
+        Bean bean = discoverBean();
+        synchronousConnect(bean);
+        bean.sendSerialMessage(new byte[] { 65, 65, 65, 65, 65, 65, 65,
+                                            65, 65, 65, 65, 65, 65 });
+        bean.readLed(new Callback<LedColor>() {
+            @Override
+            public void onResult(LedColor result) {
+                testCompletionLatch.countDown();
+            }
+        });
+        testCompletionLatch.await(10, TimeUnit.SECONDS);
+        synchronousDisconnect(bean);
+    }
+
+    @Suppress
     public void testFastSerialMessages() throws Exception {
         int times = 100;
         final CountDownLatch testCompletionLatch = new CountDownLatch(times);

--- a/sdk/src/main/java/com/punchthrough/bean/sdk/internal/serial/GattSerialTransportProfile.java
+++ b/sdk/src/main/java/com/punchthrough/bean/sdk/internal/serial/GattSerialTransportProfile.java
@@ -204,11 +204,11 @@ public class GattSerialTransportProfile extends BaseProfile {
         }
 
         // create packet, add to queue, schedule
-        int packets = (int) (message.size() / PACKET_TX_MAX_PAYLOAD_LENGTH);
+        int packets = (int) ((message.size() + PACKET_TX_MAX_PAYLOAD_LENGTH - 1) / PACKET_TX_MAX_PAYLOAD_LENGTH);
         mOutgoingMessageCount = (mOutgoingMessageCount + 1) % 4;
         int size = (int) message.size();
         for (int i = 0; i < size; i += PACKET_TX_MAX_PAYLOAD_LENGTH) {
-            GattSerialPacket packet = new GattSerialPacket(i == 0, mOutgoingMessageCount, packets--, message);
+            GattSerialPacket packet = new GattSerialPacket(i == 0, mOutgoingMessageCount, --packets, message);
             mPendingPackets.add(packet);
         }
         mHandler.post(mDequeueRunnable);


### PR DESCRIPTION
I came across an issue where the Bean with become unresponsive after writing 13 bytes. I also get the logcat message `Received message of unknown type 0x0001` when that happens. Googling seems to show a similar instance of this reported, but with scratch data ( http://beantalk.punchthrough.com/t/is-bean-still-supported-by-punchthrough/4056/2 ).

This only happens with 13 bytes, 12 bytes and 14 bytes are fine, indicating that this is possibly a boundary issue. I looked through the code, and found an issue in `GattSerialTransportProfile.sendMessage`
https://github.com/PunchThrough/bean-sdk-android/blob/dc33e8cc9258d6e028e0788d74735c75b54d1133/sdk/src/main/java/com/punchthrough/bean/sdk/internal/serial/GattSerialTransportProfile.java#L207
`int packets = (int) (message.size() / PACKET_TX_MAX_PAYLOAD_LENGTH);`
`PACKET_TX_MAX_PAYLOAD_LENGTH` is `19`
* when `message.size()` is 18, packets is `0`
* when `message.size()` is 19, packets is `1`, when it should be `0`.
* when `message.size()` is 20, packets is `1`.

I've refactored packets to indicate the number of total packets, such that:
* when `message.size()` is 18, packets is `1`
* when `message.size()` is 19, packets is `1`
* when `message.size()` is 20, packets is `2`

and changed the following `new GattSerialPacket` logic to use pre-decrement on `packets`

I've also added a test case to illustrate the issue.